### PR TITLE
Update highlight.js CDN link to the official one

### DIFF
--- a/fences.md
+++ b/fences.md
@@ -32,8 +32,8 @@ $a++;
 I don't recommend any specific syntax highlighter, but have used the following metadata to set things up.  It may or may not work for you:
 
 ```
-html header:	<link rel="stylesheet" href="http://yandex.st/highlightjs/7.3/styles/default.min.css">
-	<script src="http://yandex.st/highlightjs/7.3/highlight.min.js"></script>
+HTML Header:	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/styles/default.min.css">
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/highlight.min.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>
 ```
 


### PR DESCRIPTION
Update highlight.js CDN link to the official, and latest one, according
to
https://highlightjs.org/download/