### PR TITLE
FIXED: Crash with empty table captions

### DIFF
--- a/src/parser.leg
+++ b/src/parser.leg
@@ -1486,9 +1486,10 @@ TableCaption = b:StartList a:StartList (< BracketedText >
 	} )
 		( c:AutoLabel { b = c; b->key = TABLELABEL;})? Sp Newline
 		{
-			$$ = a;
-			$$->key = TABLECAPTION;
-
+			if ( a != NULL ) {
+				$$ = a;
+				$$->key = TABLECAPTION;
+			}
 			if ( (b != NULL) && (b->key == TABLELABEL) ) {
 				b->next = $$->children;
 				$$->children = b;


### PR DESCRIPTION
One of our customers reported that they had a crash with the following content.

```
|  |  |
|:-|:-|
|  |  |
[]
```