### PR TITLE
Adding contact address for supporting Debian Packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,8 @@ endif (WIN32)
 
 set (CPACK_PACKAGE_INSTALL_DIRECTORY ${PROJECT})
 
+set(CPACK_PACKAGE_CONTACT "fletcher@fletcherpenney.net")
+
 include (CPack)
 
 


### PR DESCRIPTION
Using the Debian packaging from cpack requires a contact e-mail address, and this PR adds that value. I've currently defaulted to the same e-mail address used in commit logs, but that was just a best guess.