### PR TITLE
Fix shared library build under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,9 +481,8 @@ set (CPACK_COMPONENTS_ALL application scripts)
 # Install Shared Library?
 if (DEFINED SHAREDBUILD)
 	install (TARGETS libMultiMarkdownShared
-		ARCHIVE
-		LIBRARY
-		DESTINATION lib
+		ARCHIVE DESTINATION lib
+		LIBRARY DESTINATION lib
 		COMPONENT sharedlib
 	)
 


### PR DESCRIPTION
Shared library build under Windows requires `ARCHIVE DESTINATION` and `LIBRARY DESTINATION` as explicit arguments, as opposed to OS X, which will accept `ARCHIVE` and `LIBRARY` not being set. This changes the arguments to work on both platforms.
