### PR TITLE
Add CriticMarkup support for LaTeX output

### DIFF
--- a/src/critic.c
+++ b/src/critic.c
@@ -115,3 +115,47 @@ void print_critic_html_highlight_node(GString *out, node *n, scratch_pad *scratc
 			break;
 	}
 }
+
+void print_critic_latex_highlight_node_tree(GString *out, node *list, scratch_pad *scratch) {
+	while (list != NULL) {
+		print_critic_latex_highlight_node(out, list, scratch);
+		list = list->next;
+	}
+}
+
+void print_critic_latex_highlight_node(GString *out, node *n, scratch_pad *scratch) {
+	if (n == NULL)
+		return;
+
+	switch (n->key) {
+		case LIST:
+			print_critic_latex_highlight_node_tree(out, n->children, scratch);
+			break;
+		case CRITICSUBSTITUTION:
+			print_critic_latex_highlight_node_tree(out, n->children, scratch);
+			break;
+		case CRITICADDITION:
+			g_string_append_printf(out, "<!--{\\color{green}\n-->");
+			print_critic_latex_highlight_node_tree(out, n->children, scratch);
+			g_string_append_printf(out, "<!--\n}-->");
+			break;
+		case CRITICCOMMENT:
+			/* Hide comments for now */
+			/* g_string_append_printf(out, "<span class=\"critic comment\">%s</span>", n->str); */
+			break;
+		case CRITICHIGHLIGHT:
+			g_string_append_printf(out, "<!--\\colorbox{yellow}{\n-->");
+			print_critic_latex_highlight_node_tree(out, n->children, scratch);
+			g_string_append_printf(out, "<!--\n}-->");
+			break;
+		case CRITICDELETION:
+			g_string_append_printf(out, "<!--{\\color{red}\n-->");
+			print_critic_latex_highlight_node_tree(out, n->children, scratch);
+			g_string_append_printf(out, "<!--\n}-->");
+			break;
+		default:
+			if(n->str)
+				g_string_append_printf(out,"%s",n->str);
+			break;
+	}
+}

--- a/src/critic.h
+++ b/src/critic.h
@@ -12,4 +12,7 @@ void print_critic_accept_node(GString *out, node *list, scratch_pad *scratch);
 void print_critic_reject_node(GString *out, node *list, scratch_pad *scratch);
 void print_critic_html_highlight_node(GString *out, node *list, scratch_pad *scratch);
 
+void print_critic_latex_highlight_node_tree(GString *out, node *list, scratch_pad *scratch);
+void print_critic_latex_highlight_node(GString *out, node *list, scratch_pad *scratch);
+
 #endif

--- a/src/libMultiMarkdown.h
+++ b/src/libMultiMarkdown.h
@@ -142,6 +142,7 @@ enum export_formats {
 	CRITIC_HTML_HIGHLIGHT_FORMAT,   //!< Used as a pre-processing step
 	LYX_FORMAT,                     //!< Developed and maintained by Charles R. Cowan
 	TOC_FORMAT,                     //!< Used as a pre-processing step
+	CRITIC_LATEX_HIGHLIGHT_FORMAT   //!< Used as a pre-processing step
 };
 
 /// These are the identifiers for node types

--- a/src/parser.leg
+++ b/src/parser.leg
@@ -1819,8 +1819,13 @@ node * parse_markdown(const char * source, unsigned long extensions, int format)
 		while (yyparse_from(&g, yy_DocForCritic));
 		
 		if (extensions & EXT_CRITIC_REJECT) {
-			if ((extensions & EXT_CRITIC_ACCEPT) && (format == HTML_FORMAT))
-				critic_resolved = export_node_tree(((parser_data *)g.data)->result, CRITIC_HTML_HIGHLIGHT_FORMAT, extensions);
+			if ((extensions & EXT_CRITIC_ACCEPT)) {
+				if(format == HTML_FORMAT) {
+					critic_resolved = export_node_tree(((parser_data *)g.data)->result, CRITIC_HTML_HIGHLIGHT_FORMAT, extensions);
+				} else if (format == LATEX_FORMAT) {
+					critic_resolved = export_node_tree(((parser_data *)g.data)->result, CRITIC_LATEX_HIGHLIGHT_FORMAT, extensions);
+				}
+			}
 			else
 				critic_resolved = export_node_tree(((parser_data *)g.data)->result, CRITIC_REJECT_FORMAT, extensions);
 		} else {

--- a/src/writer.c
+++ b/src/writer.c
@@ -41,7 +41,8 @@ char * export_node_tree(node *list, int format, unsigned long extensions) {
 	if ((format != OPML_FORMAT) &&
 		(format != CRITIC_ACCEPT_FORMAT) &&
 		(format != CRITIC_REJECT_FORMAT) &&
-		(format != CRITIC_HTML_HIGHLIGHT_FORMAT)) {
+		(format != CRITIC_HTML_HIGHLIGHT_FORMAT) &&
+		(format != CRITIC_LATEX_HIGHLIGHT_FORMAT)) {
 			/* Find defined abbreviations */
 			extract_abbreviations(list, scratch);
 			/* Apply those abbreviations to source text */
@@ -102,6 +103,12 @@ char * export_node_tree(node *list, int format, unsigned long extensions) {
 				print_latex_node_tree(out, scratch->abbreviations, scratch);
 			}
 			print_latex_node_tree(out, list, scratch);
+			break;
+		case CRITIC_LATEX_HIGHLIGHT_FORMAT:
+			if ((list != NULL) && (list->key != METADATA)) {
+				print_critic_latex_highlight_node_tree(out, scratch->abbreviations, scratch);
+			}
+			print_critic_latex_highlight_node_tree(out, list, scratch);
 			break;
 		case MEMOIR_FORMAT:
 			if ((list != NULL) && (list->key != METADATA)) {


### PR DESCRIPTION
This mimics the HTML CriticMarkup support, colorizing the LaTeX output when both `-a` and `-r` arguments are passed to multimarkdown.
