### PR TITLE
Revert "FIX: Detect a line containing only whitespace as a valid break between …"

### DIFF
--- a/src/transclude.c
+++ b/src/transclude.c
@@ -87,20 +87,10 @@ char * source_without_metadata(char * source, unsigned long extensions ) {
 		/* If we have metadata, then return just the body */
 		/* TODO: This could miss YAML Metadata that does not contain
 			blank line afterwards */
-
-		char *result = strstr(result, "\n");
-		while (result != NULL) {
-			if (*result == '\n') {
-				break;
-			} else if (isspace(*result)) {
-				++result;
-			} else {
-				result = strstr(result, "\n");
-			}
-		}
+		result = strstr(source, "\n\n");
 
 		if (result != NULL)
-			return result;
+			return result + 2;
 	}
 
 	/* No metadata, so return original pointer */


### PR DESCRIPTION
Reverts fletcher/MultiMarkdown-5#43 -- The merged changes fail the transclusion test suite.
