### PR TITLE
Fix trailing whitespace handling attempt

### DIFF
--- a/src/transclude.c
+++ b/src/transclude.c
@@ -81,26 +81,22 @@ void split_path_file(char** dir, char** file, char *path) {
 /* Return pointer to beginning of text without metadata */
 /* NOTE: This is not a new string, and does not need to be freed separately */
 char * source_without_metadata(char * source, unsigned long extensions ) {
-	char *result;
-
 	if (has_metadata(source, extensions)) {
 		/* If we have metadata, then return just the body */
-		/* TODO: This could miss YAML Metadata that does not contain
-			blank line afterwards */
+		char *result = strstr(source, "\n");
 
-		char *result = strstr(result, "\n");
-		while (result != NULL) {
+		do {
+			++result;
 			if (*result == '\n') {
 				break;
 			} else if (isspace(*result)) {
-				++result;
 			} else {
 				result = strstr(result, "\n");
 			}
-		}
+		} while(result != NULL);
 
 		if (result != NULL)
-			return result;
+			return ++result;
 	}
 
 	/* No metadata, so return original pointer */

--- a/src/transclude.c
+++ b/src/transclude.c
@@ -87,10 +87,20 @@ char * source_without_metadata(char * source, unsigned long extensions ) {
 		/* If we have metadata, then return just the body */
 		/* TODO: This could miss YAML Metadata that does not contain
 			blank line afterwards */
-		result = strstr(source, "\n\n");
+
+		char *result = strstr(result, "\n");
+		while (result != NULL) {
+			if (*result == '\n') {
+				break;
+			} else if (isspace(*result)) {
+				++result;
+			} else {
+				result = strstr(result, "\n");
+			}
+		}
 
 		if (result != NULL)
-			return result + 2;
+			return result;
 	}
 
 	/* No metadata, so return original pointer */


### PR DESCRIPTION
This fixes the issue with the original pull request #43, which had a variable shadowing bug that would introduce incorrect behavior when transcluding files with metadata. This version passes `make test` cleanly.
